### PR TITLE
ui: Reset workspace thumbnail porthole on monitor changes

### DIFF
--- a/js/ui/workspaceThumbnail.js
+++ b/js/ui/workspaceThumbnail.js
@@ -676,6 +676,9 @@ const ThumbnailsBox = new Lang.Class({
         this._settings = new Gio.Settings({ schema_id: OVERRIDE_SCHEMA });
         this._settings.connect('changed::dynamic-workspaces',
             Lang.bind(this, this._updateSwitcherVisibility));
+
+        Main.layoutManager.connect('monitors-changed',
+            Lang.bind(this, this._destroyThumbnails));
     },
 
     _updateSwitcherVisibility: function() {


### PR DESCRIPTION
The porthole will not be destroyed when the scale factor changed.
That makes workspace thumbnail porthole still wrong size in the first
seeing after the scale factor changed.